### PR TITLE
Update README

### DIFF
--- a/stapler/README
+++ b/stapler/README
@@ -3,6 +3,7 @@ Recon Phase:
 $ nmap -p 1-65535 -T4 -A -v 192.168.190.131
 $ dirb https://192.168.190.131:12380 -R
 $ nikto -host 192.168.190.131:12380
+$(If nikto doesn't work use nmap --script=http-enum <ip of target>)
 Let's scan workpress
 $ wpscan --disable-tls-checks --url https://192.168.190.131:12380/blogblog/ --enumerate u
 $ wpscan --disable-tls-checks --url https://192.168.190.131:12380/blogblog/ --enumerate p


### PR DESCRIPTION
I am not sure why nikto-h doesn't work in Kali 2020.3 in both my virtualbox and vmware setup (version - 2.1.6) however it seems to be working fine in CSI Linux (2.1.5) , so alternative NSE script I added can be used if one has a problem just like me 